### PR TITLE
Add Random as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ julia = "1.6"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Parameters", "SafeTestsets", "Test"]
+test = ["Parameters", "SafeTestsets", "Test", "Random"]

--- a/src/tests/exponential_growth.jl
+++ b/src/tests/exponential_growth.jl
@@ -9,6 +9,7 @@ module ExponentialGrowth
     using Parameters
 
     export odeproblem, odeensemble
+    using Random
 
     const x₀ = [1.0]
     const Δt = 0.1

--- a/test/initial_conditions.jl
+++ b/test/initial_conditions.jl
@@ -1,5 +1,6 @@
 
 using GeometricEquations: parameter_types
+using Random
 
 
 Δt = .1


### PR DESCRIPTION
In Julia 1.11 some work has been done to move standard libraries out of the "sysimage" and also make them upgradable (so they would no longer be strongly tied to the Julia version).
The Random stdlib is a bit special in the sense that it commits "type piracy" by overloading the `Base.rand` function for types that it doesn't own. An example of that is `rand()` which is defined in `Random`.
While code will still be able to call `rand(`) etc in 1.11 without loading `Random` there are some performance implications that makes it so it is better to load `Random` up front.
